### PR TITLE
add path check

### DIFF
--- a/tasks/windows_client.yml
+++ b/tasks/windows_client.yml
@@ -5,6 +5,10 @@
     #- include_vars: "{{ ansible_distribution }}.yml"
   - include_vars: "{{ ansible_os_family }}.yml"
 
+  - name: Ensure Temp Directory exists
+    win_file:
+      path: "{{ sensu_win_temp_path }}"
+
   - name: Download the Sensu installer msi into a local dir
     win_get_url:
       url: "{{ sensu_msi_download_path }}"

--- a/tasks/windows_client.yml
+++ b/tasks/windows_client.yml
@@ -8,6 +8,7 @@
   - name: Ensure Temp Directory exists
     win_file:
       path: "{{ sensu_win_temp_path }}"
+      state: directory
 
   - name: Download the Sensu installer msi into a local dir
     win_get_url:


### PR DESCRIPTION
Sensu deployments were failing because {{ sensu_win_temp_path }} didn't exist, in these cases C:\temp
Added a check to ensure it does exist before trying to download the installer into it.
Wondering why this branch was never merged into master btw?