### PR TITLE
Need to check apt_key_url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ pdagent_apt_repo_url: "deb     https://packages.pagerduty.com/pdagent deb/"
 # Sensu repo urls
 sensu_yum_repo_url: "http://repositories.sensuapp.org/yum/$releasever/$basearch/"
 sensu_apt_repo_url: "deb     http://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
-sensu_apt_key_url: "http://repositories.sensuapp.org/apt/pubkey.gpg"
+sensu_apt_key_url: "https://eol-repositories.sensuapp.org/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"
 
 # Sensu service names


### PR DESCRIPTION
Noticed that the master deployments were still failing.
It turns out we use two branches for sensu deployments in this repo:
master -> for the sensu master in each region
add-windows-support -> for the clients in each region

So this merge is required to get the masters to re-deploy each week work again