### PR TITLE
Change sensu client version

### DIFF
--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,4 +1,4 @@
 sensu_client_config: "windows_client.json.j2"
 sensu_win_rabbitmq_config: "windows-sensu-rabbitmq.json.j2"
-sensu_msi_download_path: "https://eol-repositories.sensuapp.org/msi/2016/sensu-1.6.2-2-x64.msi"
+sensu_msi_download_path: "https://eol-repositories.sensuapp.org/msi/2016/sensu-1.9.0-1-x64.msi"
 sensu_msi_product_id: "{D58481B8-1455-4404-B5C7-E488D6699DD3}"


### PR DESCRIPTION
Updating Sensu client to latest (eol) release.
Our masters are already 1.9 so will be compatible.

Tests:
Deployed new sensu client to server in DEV Account:
https://jenkins.copperleaf.cloud/job/DevOps/job/sensu/job/DEV/job/sensu_client_deployment-windows/15/console

Confirmed functionality of client by going into DEV Sensu and making sure that the client was able to connect and checks are being executed:
![image](https://user-images.githubusercontent.com/37155880/75142117-b7fe4900-5735-11ea-80f5-b9295f08cf2f.png)
