### PR TITLE
Update rabbitmq repos

### DIFF
--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -4,14 +4,16 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
+  # https://www.rabbitmq.com/signatures.html
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
-      url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+      url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
       state: present
 
+  # https://www.rabbitmq.com/install-debian.html
   - name: Ensure the RabbitMQ APT repo is present
     apt_repository:
-      repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+      repo: "deb https://packagecloud.io/rabbitmq/rabbitmq-server/debian/ {{ ansible_distribution_release }} main"
       filename: rabbitmq
       state: present
       update_cache: true

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -4,14 +4,16 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
+  # https://www.rabbitmq.com/signatures.html
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
-      url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+      url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
       state: present
 
+  # https://www.rabbitmq.com/install-debian.html
   - name: Ensure the RabbitMQ APT repo is present
     apt_repository:
-      repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+      repo: "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_distribution_release }} main"
       filename: rabbitmq
       state: present
       update_cache: true

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -5,6 +5,11 @@
   - include_vars: "{{ ansible_distribution }}.yml"
 
   # https://www.rabbitmq.com/signatures.html
+  - name: Ensure the PackageCloud APT repo GPG key is present
+    apt_key:
+      url: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
+      state: present
+
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
       url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc


### PR DESCRIPTION
RabbitMQ has moved their APT packages to PackageCloud from BinTray as BinTray is sunsetting.

This updates the APT repos for Debian and Ubuntu targets.

Successful deployment: https://jenkins.copperleaf.cloud/job/DevOps/job/sensu/job/PROD/job/sensu_master_deployment/209/console