### PR TITLE
Pinning rabbitmq server version to known good 3.9.23-1

### DIFF
--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -37,7 +37,8 @@
 
   - name: Ensure RabbitMQ is installed
     apt:
-      name: rabbitmq-server
+      name: rabbitmq-server=3.9.23-1
+      allow_downgrade: true
       state: "{{ rabbitmq_pkg_state }}"
       cache_valid_time: 600
       update_cache: true


### PR DESCRIPTION
3.11.x is breaking Sensu Core (https://jenkins.copperleaf.cloud/job/DevOps/job/sensu/job/PROD/job/sensu_master_deployment/300/consoleFull)

