### PR TITLE
Update client.json.j2

### DIFF
--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -9,7 +9,6 @@
         "Team": "{{ ec2_tag_Team | default('') }}",
         "Customer": "{{ ec2_tag_Customer | default('') }}",
         "CostCenter": "{{ ec2_tag_CostCenter | default('') }}",
-        "Admins": "{{ ec2_tag_Admins | default('') }}"
     },
     "keepalive": {
       "handlers": {{ sensu_client_keepalive_handlers | to_nice_json(indent=8) }},


### PR DESCRIPTION
Removing SIP tool admin list from the sensu client subscriptions as this causing text formatting issues in the C:\opt\sensu\conf.d\client.json file and sensu client to not start on the SEW-C55-Oracle-RDS server. Confirmed that the SIP tool admin list is not needed in the C:\opt\sensu\conf.d\client.json file in order for sensu to function.

Successful sensu client deployment in dev account on test server amytestdev5 using this branch. Confirmed it connects to the sensu master server in that region and checks are being performed. https://jenkins.copperleaf.cloud/job/DevOps/job/sensu/job/DEV/job/sensu_client_deployment-windows/220/console

![image](https://github.com/copperleaftech/sensu-client-deployment/assets/45666852/0133e76d-8f10-46a3-9108-db3cba456452)

